### PR TITLE
Remove non-standard header file and replace non-standard types

### DIFF
--- a/src/glimpse.cpp
+++ b/src/glimpse.cpp
@@ -31,8 +31,7 @@
  * knowledge of the CeCILL license and that you accept its terms.
  *
  */
-#include <stdio.h>
-#include <stdlib.h>
+
 #include <iostream>
 #include <fstream>
 #include <CCfits/CCfits>

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -53,8 +53,8 @@ spg::spg ( int npix, int nz, int nframes, const double *P, const float *l1_weigh
     d_w     = ( float ** ) malloc ( sizeof ( float * ) * nGPU );
 
     // Stride between coefficients processed by different GPUs
-    coeff_stride = ( ulong * ) malloc ( sizeof ( ulong ) * nGPU );
-    coeff_stride_pos = ( ulong * ) malloc ( sizeof ( ulong ) * nGPU );
+    coeff_stride = ( unsigned long * ) malloc ( sizeof ( unsigned long ) * nGPU );
+    coeff_stride_pos = ( unsigned long * ) malloc ( sizeof ( unsigned long ) * nGPU );
 
     // Memory allocation for all GPUs
     for ( int i = 0; i < nGPU; i++ ) {

--- a/src/spg.h
+++ b/src/spg.h
@@ -48,8 +48,8 @@ class spg
     int whichGPUs[MAX_GPUS];
     
     // Stride between coefficients proccessed by different GPUs
-    ulong * coeff_stride;
-    ulong * coeff_stride_pos;
+    unsigned long * coeff_stride;
+    unsigned long * coeff_stride_pos;
         
     // Device pointer arrays, storing  pointers for each device
     float ** d_x;


### PR DESCRIPTION
`stdio.h` and `stdlib.h` are C header files and should not be imported in C++ code.  Also, `ufloat` is a non-standard type, some systems happen to provide this convenient alias for `unsigned long`, but it's not generally available.